### PR TITLE
Remove as many init() functions as is reasonable

### DIFF
--- a/dashboard.go
+++ b/dashboard.go
@@ -43,6 +43,10 @@ func index(w http.ResponseWriter, r *http.Request) {
 }
 
 func Listen(bindAddr string) error {
+	// Replace init()'s with explicit inline initializations
+	githubClient = newGitHubClient()
+	initProjects()
+
 	http.HandleFunc("/reset.json", reset)
 	http.HandleFunc("/show.json", show)
 	http.Handle("/triage", triage.New(githubClient, []string{"documentation", "bug", "enhancement"}))

--- a/github.go
+++ b/github.go
@@ -176,10 +176,6 @@ type githubCIContext struct {
 	TypeName string `json:"__typename"`
 }
 
-func init() {
-	githubClient = newGitHubClient()
-}
-
 func gitHubToken() string {
 	return os.Getenv(accessTokenEnvVar)
 }

--- a/http.go
+++ b/http.go
@@ -10,12 +10,8 @@ import (
 	gh "github.com/google/go-github/v37/github"
 )
 
-var throttle <-chan time.Time
-
-func init() {
-	rate := time.Second / 30
-	throttle = time.Tick(rate)
-}
+var allowRequestEvery = time.Second / 30
+var throttle <-chan time.Time = time.Tick(allowRequestEvery)
 
 func logHTTP(method, url string, f func()) {
 	log.Println("==> ", method, url)

--- a/project.go
+++ b/project.go
@@ -8,7 +8,7 @@ import (
 
 var defaultProjectMap = sync.Map{}
 
-func init() {
+func initProjects() {
 	for _, p := range defaultProjects {
 		defaultProjectMap.Store(p.Name, p)
 	}

--- a/triage/template.go
+++ b/triage/template.go
@@ -96,7 +96,7 @@ Filter by using the <b>type</b> (issue/pr/all), <b>label</b> (see below), or <b>
 `
 )
 
-func init() {
+func initTemplates() {
 	var err error
 	triageTmpl, err = template.New("triage").Funcs(template.FuncMap{
 		"daysAgo":   daysAgo,

--- a/triage/triage.go
+++ b/triage/triage.go
@@ -5,12 +5,16 @@ import (
 	"log"
 	"net/http"
 	"sort"
+	"sync"
 	"time"
 
 	"github.com/google/go-github/v37/github"
 )
 
+var once sync.Once
+
 func New(client *github.Client, labelsofInterest []string) *Triager {
+	once.Do(initTemplates)
 	return &Triager{
 		Client:           client,
 		LabelsOfInterest: labelsofInterest,


### PR DESCRIPTION
Run what needs to be run before `dashboard.Listen(bindAddr)` instead.

init() methods are generally bad practice since anyone that depends on your code will be forced to run these methods as well. I was making network connections to prefill the GitHub data for the projects which was not good.